### PR TITLE
Modify env variables on docker-compose.yml, without quotation marks and add version of package eth2stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
     environment:
       - NODE_NAME=DAppNode
       - BEACON_TYPE=prysm
-      - 'BEACON_ADDR=prysm-medalla-beacon-chain.dappnode:4000'
-      - 'BEACON_METRICS=http://prysm-medalla-beacon-chain.dappnode:8080/metrics'
-      - 'ADDR=grpc.medalla.eth2stats.io:443'
+      - BEACON_ADDR=prysm-medalla-beacon-chain.dappnode:4000
+      - BEACON_METRICS=http://prysm-medalla-beacon-chain.dappnode:8080/metrics
+      - ADDR=grpc.medalla.eth2stats.io:443
     volumes:
       - 'data:/data'
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./build
       args:
-        - VERSION
+        - VERSION=v0.0.16
     image: 'eth2stats-client.dnp.dappnode.eth:0.1.0'
     restart: always
     environment:


### PR DESCRIPTION
I suppose that will be the fault for which it does not take the environment variables, and add version of package eth2stats. related to #1 